### PR TITLE
Option to send only aggregate CPU stats

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ const (
 	DEFAULT_PROFILE_PORT = "0"                                                                // Default profile port, 0 disables
 	DEFAULT_DF_TYPES     = "btrfs,ext3,ext4,tmpfs,xfs"                                        // Default fs types to report df for
 	DEFAULT_NIF_DEVICES  = "eth0,lo"                                                          // Default interfaces to report stats for
+	DEFAULT_CPU_AGGR     = false                                                              // Default whether to only report aggregate CPU
 )
 
 var (
@@ -26,6 +27,7 @@ var (
 	Listen              = utils.GetEnvWithDefault("SHH_LISTEN", "unix,#shh")                                     // Default network socket info for listen
 	NifDevices          = utils.GetEnvWithDefaultStrings("SHH_NIF_DEVICES", DEFAULT_NIF_DEVICES)                 // Devices to poll
 	NtpdateServers      = utils.GetEnvWithDefaultStrings("SHH_NTPDATE_SERVERS", "0.pool.ntp.org,1.pool.ntp.org") // NTP Servers
+	CpuOnlyAggregate    = utils.GetEnvWithDefaultBool("SHH_CPU_AGGR", false)                                     // Whether to only report aggregate CPU usage
 	LibratoUser         = utils.GetEnvWithDefault("SHH_LIBRATO_USER", "")                                        // The Librato API User
 	LibratoToken        = utils.GetEnvWithDefault("SHH_LIBRATO_TOKEN", "")                                       // The Librato API TOken
 	LibratoBatchSize    = utils.GetEnvWithDefaultInt("SHH_LIBRATO_BATCH_SIZE", 50)                               // The max number of metrics to submit in a single request

--- a/pollers/cpu.go
+++ b/pollers/cpu.go
@@ -1,6 +1,7 @@
 package pollers
 
 import (
+	"github.com/freeformz/shh/config"
 	"github.com/freeformz/shh/mm"
 	"github.com/freeformz/shh/utils"
 	"strings"
@@ -61,6 +62,10 @@ func (poller Cpu) Poll(tick time.Time) {
 		if strings.HasPrefix(line, "cpu") {
 			fields := strings.Fields(line)
 			cpu := fields[0]
+
+			if config.CpuOnlyAggregate && cpu != "cpu" {
+				continue
+			}
 
 			current = CpuValues{
 				User:    utils.Atofloat64(fields[1]),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -148,6 +148,21 @@ func GetEnvWithDefaultInt(env string, def int) int {
 	return i
 }
 
+// Returns the value of $env from the OS and if it's empty, returns def
+func GetEnvWithDefaultBool(env string, def bool) bool {
+	tmp := os.Getenv(env)
+
+	if tmp == "" {
+		return def
+	}
+
+	b, err := strconv.ParseBool(tmp)
+	if err != nil {
+		Slog{"fn": "GetEnvWithDefaultBool", "env": env, "def": def}.FatalError(err, "converting atob")
+	}
+	return b
+}
+
 func GetEnvWithDefaultDuration(env string, def string) time.Duration {
 	tmp := os.Getenv(env)
 


### PR DESCRIPTION
This introduces an option `SHH_CPU_AGGR` which prevents shh from sending stats for each core (thereby only sending the aggregate `cpu` line).

Use case: we have a server that reports 32 cores in `/proc/stat` and this poller very rapidly becomes a disk space hog. I could address this by changing the retention on `cpu(\d+)` fields, but I'd rather not send the stats at all. 
